### PR TITLE
Fix to parsing of existing IAM role policy

### DIFF
--- a/provision_utils.go
+++ b/provision_utils.go
@@ -103,10 +103,10 @@ func ensureIAMRoleResource(awsPrincipalName string, sourceArn string, resources 
 	// If it exists, make sure these permissions are enabled on it...
 	if exists {
 		statementExists := false
-		properties := existingResource.(ArbitraryJSONObject)["existingResource"]
+		properties := existingResource.(ArbitraryJSONObject)["Properties"]
 		policies := properties.(ArbitraryJSONObject)["Policies"]
 		for _, eachPolicy := range policies.([]ArbitraryJSONObject) {
-			statements := eachPolicy["Statement"]
+			statements := eachPolicy["PolicyDocument"].(ArbitraryJSONObject)["Statement"]
 			for _, eachStatement := range statements.([]ArbitraryJSONObject) {
 				if eachStatement["Resource"] == sourceArn {
 					statementExists = true


### PR DESCRIPTION
During provisioning I was running into an error when trying to check for an existing SNS permission policy. I have code like this to define the permission:

```
lambdaWelcome := sparta.NewLambda(roleDefinition, sendWelcomeEmail, welcomeOptions)

    lambdaWelcome.Permissions = append(lambdaWelcome.Permissions, sparta.SNSPermission{
        BasePermission: sparta.BasePermission{
            SourceArn: "arn:aws:sns:eu-west-1:7056640223706:development__global__user__didJoin",
        },
    })
```

And I was getting the following error:

```
DEBU[0016] Ensuring IAM Role results                     Principal=sns.amazonaws.com PrincipalActions=[sns:ConfirmSubscription sns:GetTopicAttributes sns:Subscribe sns:Unsubscribe]
panic: interface conversion: interface {} is nil, not sparta.ArbitraryJSONObject

goroutine 1 [running]:
github.com/mweagle/Sparta.ensureIAMRoleResource(0x728db0, 0x11, 0x7ac2a0, 0x4c, 0xc820112750, 0xc820076e40, 0x0, 0x0, 0x0, 0x0)
    /Users/jbrook/go-projects/src/github.com/mweagle/Sparta/provision_utils.go:107 +0x15b0
github.com/mweagle/Sparta.ensureConfiguratorLambdaResource(0x728db0, 0x11, 0x7ac2a0, 0x4c, 0xc820112750, 0x7fff5fbff72b, 0x19, 0xc82000a163, 0x17, 0xc820076e40, ...)
    /Users/jbrook/go-projects/src/github.com/mweagle/Sparta/provision_utils.go:46 +0xf8
```

It seems like the structure coming back for the resource in my case was rather different from what the code was expecting.
